### PR TITLE
minor fix in INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -19,7 +19,7 @@ conda install <package_name>
 ### Installing the package
 
 ```bash
-    cd pygromos
+    cd PyGromosTools
     python setup.py install
 ```
 


### PR DESCRIPTION
very minor correction, since the repository is called PyGromosTools, the installation instruction should use `cd PyGromosTools` instead of `cd pygromos`
