### PR TITLE
fix for parsing correct number of nonbondeds

### DIFF
--- a/pygromos/files/trajectory/blocks/energy_trajectory_subblock.py
+++ b/pygromos/files/trajectory/blocks/energy_trajectory_subblock.py
@@ -23,6 +23,7 @@ class _general_pandas_energy_trajectory_subblock_numerated(_general_pandas_energ
     # first define some static variables for the stupid gromos format
     num_energy_baths = 0
     num_force_groups = 0
+    num_nbforce_groups = 0
     num_num_states = 0
     num_temp_groups = 0
     num_lambdas = 0
@@ -36,6 +37,8 @@ class _general_pandas_energy_trajectory_subblock_numerated(_general_pandas_energ
             num_subsubblocks = _general_pandas_energy_trajectory_subblock_numerated.num_energy_baths
         elif subsubblock_number_code == "force":
             num_subsubblocks = _general_pandas_energy_trajectory_subblock_numerated.num_force_groups
+        elif subsubblock_number_code == "nbforce":
+            num_subsubblocks = _general_pandas_energy_trajectory_subblock_numerated.num_nbforce_groups
         elif subsubblock_number_code == "states":
             num_subsubblocks = _general_pandas_energy_trajectory_subblock_numerated.num_num_states
         elif subsubblock_number_code == "lambda":
@@ -44,7 +47,7 @@ class _general_pandas_energy_trajectory_subblock_numerated(_general_pandas_energ
             num_subsubblocks = _general_pandas_energy_trajectory_subblock_numerated.num_temp_groups
         else:
             raise KeyError("subblock number coder does not corresponde to variable")
-        
+
         # get the number of baths
         if num_subsubblocks == 0:
             try:
@@ -59,6 +62,7 @@ class _general_pandas_energy_trajectory_subblock_numerated(_general_pandas_energ
                 _general_pandas_energy_trajectory_subblock_numerated.num_energy_baths = num_subsubblocks
             elif subsubblock_number_code == "force":
                 _general_pandas_energy_trajectory_subblock_numerated.num_force_groups = num_subsubblocks
+                _general_pandas_energy_trajectory_subblock_numerated.num_nbforce_groups = sum([x for x in range(1, num_subsubblocks+1)])
             elif subsubblock_number_code == "states":
                 _general_pandas_energy_trajectory_subblock_numerated.num_num_states = num_subsubblocks
             elif subsubblock_number_code == "lambda":
@@ -77,6 +81,7 @@ class _general_pandas_energy_trajectory_subblock_numerated(_general_pandas_energ
 
     def to_dict(self) -> dict:
         return {self.blockName: self.matrix}
+
 
 
 class totals(_general_pandas_energy_trajectory_subblock):
@@ -105,7 +110,7 @@ class bonded(_general_pandas_energy_trajectory_subblock_numerated):
 
 class nonbonded(_general_pandas_energy_trajectory_subblock_numerated):
     def __init__(self, content):
-        super().__init__(content, subsubblock_number_code="force")
+        super().__init__(content, subsubblock_number_code="nbforce")
         self.blockName = "nonbonded"
     
     def to_dict(self) -> dict:

--- a/pygromos/files/trajectory/tre.py
+++ b/pygromos/files/trajectory/tre.py
@@ -45,12 +45,36 @@ class Tre(traj._General_Trajectory):
         self.totals_total = self.database["totals"].apply(lambda x: x[0])
         return self.totals_total
 
-    def get_totals_bonded(self) -> pd.DataFrame:
+    def get_totals_totkin(self) -> pd.DataFrame:
         self.totals_bonded = self.database["totals"].apply(lambda x: x[1])
         return self.totals_bonded
 
-    def get_totals_nonbonded(self) -> pd.DataFrame:
-        self.totals_nonbonded = self.database["totals"].apply(lambda x: x[2])
+    def get_totals_totcov(self) -> pd.DataFrame:
+        self.totals_nonbonded = self.database["totals"].apply(lambda x: x[3])
+        return self.totals_nonbonded
+
+    def get_totals_totbond(self) -> pd.DataFrame:
+        self.totals_nonbonded = self.database["totals"].apply(lambda x: x[4])
+        return self.totals_nonbonded
+
+    def get_totals_totangle(self) -> pd.DataFrame:
+        self.totals_nonbonded = self.database["totals"].apply(lambda x: x[5])
+        return self.totals_nonbonded
+
+    def get_totals_totdihedral(self) -> pd.DataFrame:
+        self.totals_nonbonded = self.database["totals"].apply(lambda x: x[7])
+        return self.totals_nonbonded
+
+    def get_totals_totnonbonded(self) -> pd.DataFrame:
+        self.totals_nonbonded = self.database["totals"].apply(lambda x: x[9])
+        return self.totals_nonbonded
+
+    def get_totals_totlj(self) -> pd.DataFrame:
+        self.totals_nonbonded = self.database["totals"].apply(lambda x: x[10])
+        return self.totals_nonbonded
+
+    def get_totals_totcrf(self) -> pd.DataFrame:
+        self.totals_nonbonded = self.database["totals"].apply(lambda x: x[11])
         return self.totals_nonbonded
 
     def get_eds(self)->pd.DataFrame:
@@ -111,12 +135,12 @@ class Tre(traj._General_Trajectory):
     def get_Hvap(self, gas_traj, nMolecules=1, temperature=None) -> float:
         gas_nonbonded_energy = 0
         if type(gas_traj) == type(self):
-            gas_nonbonded_energy = gas_traj.get_totals_nonbonded().mean()
+            gas_nonbonded_energy = gas_traj.get_totals_totpot().mean()
         elif type(gas_traj) == float:
             gas_nonbonded_energy = gas_traj
         else:
             raise TypeError("Did not understand the type of gas. Allowed are float (E_gas) or Tre (gas_trajectory)")
-        liquid_nonbonded_energyself = self.get_totals_nonbonded().mean()
+        liquid_nonbonded_energyself = self.get_totals_totpot().mean()
 
         # calculate heat of vaporization
         self.heat_vap = ea.get_Hvap(liq=liquid_nonbonded_energyself, gas=gas_nonbonded_energy, temperature=temperature, nMolecules=nMolecules)

--- a/pygromos/files/trajectory/tre.py
+++ b/pygromos/files/trajectory/tre.py
@@ -42,39 +42,39 @@ class Tre(traj._General_Trajectory):
         return self.totals
 
     def get_totals_total(self) -> pd.DataFrame:
-        self.totals_total = self.database["totals"].apply(lambda x: x[0])
+        self.totals_total = self.database["totals"].apply(lambda x: x[self.tre_block_name_table.totals_subblock_names.index['totene']])
         return self.totals_total
 
     def get_totals_totkin(self) -> pd.DataFrame:
-        self.totals_bonded = self.database["totals"].apply(lambda x: x[1])
+        self.totals_bonded = self.database["totals"].apply(lambda x: x[self.tre_block_name_table.totals_subblock_names.index['totkin']])
         return self.totals_bonded
 
     def get_totals_totcov(self) -> pd.DataFrame:
-        self.totals_nonbonded = self.database["totals"].apply(lambda x: x[3])
+        self.totals_nonbonded = self.database["totals"].apply(lambda x: x[self.tre_block_name_table.totals_subblock_names.index['totcov']])
         return self.totals_nonbonded
 
     def get_totals_totbond(self) -> pd.DataFrame:
-        self.totals_nonbonded = self.database["totals"].apply(lambda x: x[4])
+        self.totals_nonbonded = self.database["totals"].apply(lambda x: x[self.tre_block_name_table.totals_subblock_names.index['totbond']])
         return self.totals_nonbonded
 
     def get_totals_totangle(self) -> pd.DataFrame:
-        self.totals_nonbonded = self.database["totals"].apply(lambda x: x[5])
+        self.totals_nonbonded = self.database["totals"].apply(lambda x: x[self.tre_block_name_table.totals_subblock_names.index['totangle']])
         return self.totals_nonbonded
 
     def get_totals_totdihedral(self) -> pd.DataFrame:
-        self.totals_nonbonded = self.database["totals"].apply(lambda x: x[7])
+        self.totals_nonbonded = self.database["totals"].apply(lambda x: x[self.tre_block_name_table.totals_subblock_names.index['totdihedral']])
         return self.totals_nonbonded
 
     def get_totals_totnonbonded(self) -> pd.DataFrame:
-        self.totals_nonbonded = self.database["totals"].apply(lambda x: x[9])
+        self.totals_nonbonded = self.database["totals"].apply(lambda x: x[self.tre_block_name_table.totals_subblock_names.index['totnonbonded']])
         return self.totals_nonbonded
 
     def get_totals_totlj(self) -> pd.DataFrame:
-        self.totals_nonbonded = self.database["totals"].apply(lambda x: x[10])
+        self.totals_nonbonded = self.database["totals"].apply(lambda x: x[self.tre_block_name_table.totals_subblock_names.index['totlj']])
         return self.totals_nonbonded
 
     def get_totals_totcrf(self) -> pd.DataFrame:
-        self.totals_nonbonded = self.database["totals"].apply(lambda x: x[11])
+        self.totals_nonbonded = self.database["totals"].apply(lambda x: x[self.tre_block_name_table.totals_subblock_names.index['totcrfs']])
         return self.totals_nonbonded
 
     def get_eds(self)->pd.DataFrame:


### PR DESCRIPTION
accedentially so far, we parsed the same amount of row from the nonbonded block, like we parsed for the bonded terms. but nonbondeds actually form a matrix - force group with each other force group:

leading to if we have 3 bondeds, we actually should read 3+2+1 =6 nonbonded rows (interaction grp1-grp1, grp1-grp2, grp1-grp3, grp2-grp2, ... and so on)