### PR TITLE
Added rgyr function

### DIFF
--- a/pygromos/gromos/gromosPP.py
+++ b/pygromos/gromos/gromosPP.py
@@ -1102,6 +1102,50 @@ class _gromosPPbase:
     def _gr962pdb(self):
         raise Exception('not implemented yet!')
 
+    @gromosTypeConverter
+    def rgyr(self, out_rgyr_path:str, in_coord_path:str, in_top_path:str, atom_selection:str, periodic_boundary_condition:str="r cog", time:int=None, dt:int=None,  
+    binary_name:str= "rgyr", mass_weighted:bool=False)->str:
+        """
+        This wrapper uses rgyr to compute the radius of gyration. 
+
+        Parameters
+        ----------
+        out_rgyr_path: str
+        in_coord_path: str
+        in_top_path: str
+        atom_selection: str
+        periodic_boundary_condition: str
+        time: int, optional
+        dt: int, optional
+
+        Returns
+        -------
+        str
+            returns out_rgyr_path
+
+        See Also
+        --------
+             For more information checkout the Gromos Manual
+        """
+
+        args = ["@topo " + in_top_path,
+                "@pbc " + periodic_boundary_condition,
+                "@atoms " + atom_selection,
+                "@traj " + in_coord_path]
+
+        if(not isinstance(time, type(None))):
+            args += "@time "+str(time)+" "
+        if(not isinstance(time, type(None)) and not isinstance(dt, type(None))):
+            args += " "+str(dt)+" "
+        #arg_path = os.path.dirname(out_top_path) + "/topargs.arg"
+        #arg_file = open(arg_path, "w")
+        #arg_file.write("\n".join(args))
+        #arg_file.close()
+        #"@f " + arg_path
+        command = self._bin +"rgyr "+" ".join(args)
+        bash.execute(command, catch_STD=out_rgyr_path)
+        return out_rgyr_path
+
 
 class GromosPP(_gromosPPbase):
     """

--- a/pygromos/gromos/gromosPP.py
+++ b/pygromos/gromos/gromosPP.py
@@ -1104,7 +1104,7 @@ class _gromosPPbase:
 
     @gromosTypeConverter
     def rgyr(self, out_rgyr_path:str, in_coord_path:str, in_top_path:str, atom_selection:str, periodic_boundary_condition:str="r cog", time:int=None, dt:int=None,  
-    _binary_name:str= "rgyr", mass_weighted:bool=False)->str:
+    mass_weighted:bool=False, _binary_name:str= "rgyr")->str:
         """
         This wrapper uses rgyr to compute the radius of gyration for a given atom selection. 
 
@@ -1117,6 +1117,8 @@ class _gromosPPbase:
         periodic_boundary_condition: str
         time: int, optional
         dt: int, optional
+	mass_weighted:bool, optional
+	_binary_name: str, optional
 
         Returns
         -------

--- a/pygromos/gromos/gromosPP.py
+++ b/pygromos/gromos/gromosPP.py
@@ -163,7 +163,7 @@ class _gromosPPbase:
         return out_path
 
     @gromosTypeConverter
-    def make_top(self, out_top_path:str, in_building_block_lib_path: str, in_parameter_lib_path: str, in_sequence:str, in_solvent:str= "H2O", additional_options="\n")->str:
+    def make_top(self, out_top_path:str, in_building_block_lib_path: str, in_parameter_lib_path: str, in_sequence:str, in_solvent:str= "H2O", additional_options="\n", _binary_name:str= "make_top")->str:
         """
         This wrapper uses make_top to generate a topology file.
 
@@ -199,7 +199,7 @@ class _gromosPPbase:
         #arg_file.write("\n".join(args))
         #arg_file.close()
         #"@f " + arg_path
-        command = self._bin +"make_top "+" ".join(args)
+        command = self._bin +_binary_name +" "+" ".join(args)
         bash.execute(command, catch_STD=out_top_path)
         return out_top_path
 
@@ -1104,9 +1104,9 @@ class _gromosPPbase:
 
     @gromosTypeConverter
     def rgyr(self, out_rgyr_path:str, in_coord_path:str, in_top_path:str, atom_selection:str, periodic_boundary_condition:str="r cog", time:int=None, dt:int=None,  
-    binary_name:str= "rgyr", mass_weighted:bool=False)->str:
+    _binary_name:str= "rgyr", mass_weighted:bool=False)->str:
         """
-        This wrapper uses rgyr to compute the radius of gyration. 
+        This wrapper uses rgyr to compute the radius of gyration for a given atom selection. 
 
         Parameters
         ----------
@@ -1137,12 +1137,8 @@ class _gromosPPbase:
             args += "@time "+str(time)+" "
         if(not isinstance(time, type(None)) and not isinstance(dt, type(None))):
             args += " "+str(dt)+" "
-        #arg_path = os.path.dirname(out_top_path) + "/topargs.arg"
-        #arg_file = open(arg_path, "w")
-        #arg_file.write("\n".join(args))
-        #arg_file.close()
-        #"@f " + arg_path
-        command = self._bin +"rgyr "+" ".join(args)
+	
+        command = self._bin +_binary_name+" "+" ".join(args)
         bash.execute(command, catch_STD=out_rgyr_path)
         return out_rgyr_path
 


### PR DESCRIPTION
## Description
I added a wrapper function for the gromos++ binary rgyr.

The following test worked and creates a .dat file with the radius of gyration:

```
from pygromos.gromos import gromosPP

import os

current_dir = os.getcwd()

topo = current_dir + "/menthol_600dmf_54a7.top"
pbc = "r cog"
atoms = "1:a"
traj = current_dir + "/md_menthol_1.trc.gz"
out = current_dir + "/rgyr.dat"

helper = gromosPP.GromosPP("/cluster/project/igc/fpultar/bin/gromos++/bin")
helper.rgyr(out_rgyr_path=out, in_coord_path=traj, in_top_path=topo, atom_selection=atoms)
````

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [ ] rgyr is now wrapped

## Status
- [x] Ready to go