### PR TITLE
Add documentation+ two additional options+ minor fixes  to ti_modules.py 

### DIFF
--- a/pygromos/files/blocks/imd_blocks.py
+++ b/pygromos/files/blocks/imd_blocks.py
@@ -293,12 +293,12 @@ class REPLICA(_generic_imd_block):
                  CONT: bool=False, content=None):
         super().__init__(used=True, content=content)
         if content is None:
-            self.RETL = bool(RETL)
+            self.RETL = int(RETL)
 
             self.NRET = int(NRET)
             self.RET = RET
 
-            self.LRESCALE = bool(LRESCALE)
+            self.LRESCALE = int(LRESCALE)
 
             self.NRELAM = int(NRELAM)
             self.RELAM = RELAM
@@ -306,7 +306,7 @@ class REPLICA(_generic_imd_block):
 
             self.NRETRIAL = int(NRETRIAL)
             self.NREQUIL = int(NREQUIL)
-            self.CONT = bool(CONT)
+            self.CONT = int(CONT)
 
     def read_content_from_str(self, content: List[str]):
         try:
@@ -317,7 +317,6 @@ class REPLICA(_generic_imd_block):
                 setattr(self, "RET", T_values)
             else:
                 raise IOError("REPLICA: NRET was not equal to the number of Temperatures (RET) in IMD!")
-            
             setattr(self, "LRESCALE", int(content[7].split()[0]))
             setattr(self, "NRELAM", int(content[9].split()[0]))
             lambda_val =  list(map(float, content[11].split()))
@@ -333,8 +332,6 @@ class REPLICA(_generic_imd_block):
             [setattr(self, key, int(value)) for key, value in zip(self._order[0][-1], content[-1].split()) ]
         except Exception as err:
             raise IOError("Could not parse block from str - "+__class__.__name__+"\n"+str(err.args))
-
-
 
 class NEW_REPLICA_EDS(_generic_imd_block):
     """REPLICA_EDS Block

--- a/pygromos/files/blocks/imd_blocks.py
+++ b/pygromos/files/blocks/imd_blocks.py
@@ -293,12 +293,12 @@ class REPLICA(_generic_imd_block):
                  CONT: bool=False, content=None):
         super().__init__(used=True, content=content)
         if content is None:
-            self.RETL = int(RETL)
+            self.RETL = bool(RETL)
 
             self.NRET = int(NRET)
             self.RET = RET
 
-            self.LRESCALE = int(LRESCALE)
+            self.LRESCALE = bool(LRESCALE)
 
             self.NRELAM = int(NRELAM)
             self.RELAM = RELAM
@@ -306,7 +306,7 @@ class REPLICA(_generic_imd_block):
 
             self.NRETRIAL = int(NRETRIAL)
             self.NREQUIL = int(NREQUIL)
-            self.CONT = int(CONT)
+            self.CONT = bool(CONT)
 
     def read_content_from_str(self, content: List[str]):
         try:

--- a/pygromos/files/blocks/imd_blocks.py
+++ b/pygromos/files/blocks/imd_blocks.py
@@ -317,6 +317,8 @@ class REPLICA(_generic_imd_block):
                 setattr(self, "RET", T_values)
             else:
                 raise IOError("REPLICA: NRET was not equal to the number of Temperatures (RET) in IMD!")
+            
+            setattr(self, "LRESCALE", int(content[7].split()[0]))
             setattr(self, "NRELAM", int(content[9].split()[0]))
             lambda_val =  list(map(float, content[11].split()))
             if(len(lambda_val)== self.NRELAM):
@@ -329,7 +331,6 @@ class REPLICA(_generic_imd_block):
             else:
                 raise IOError("REPLICA: NRELAM was not equal to the number of lambda timestep values (RETS) in IMD!")
             [setattr(self, key, int(value)) for key, value in zip(self._order[0][-1], content[-1].split()) ]
-
         except Exception as err:
             raise IOError("Could not parse block from str - "+__class__.__name__+"\n"+str(err.args))
 

--- a/pygromos/files/simulation_parameters/imd.py
+++ b/pygromos/files/simulation_parameters/imd.py
@@ -76,6 +76,8 @@ class Imd(_general_gromos_file._general_gromos_file):
 
     REPLICA_EDS: blocks.REPLICA_EDS
     NEW_REPLICA_EDS: blocks.NEW_REPLICA_EDS
+    
+    REPLICA: blocks.REPLICA
 
     QMMM: blocks.QMMM
 

--- a/pygromos/simulations/modules/ti_modules.py
+++ b/pygromos/simulations/modules/ti_modules.py
@@ -5,9 +5,11 @@
 from collections import OrderedDict
 from typing import List
 import numpy as np
+from copy import deepcopy
 
 from pygromos.files.blocks.imd_blocks import PERTURBATION, PRECALCLAM
 from pygromos.files.gromos_system import Gromos_System
+from pygromos.files.coord.cnf import Cnf
 from pygromos.simulations.hpc_queuing.job_scheduling.workers.analysis_workers import simulation_analysis
 from pygromos.simulations.hpc_queuing.submission_systems._submission_system import _SubmissionSystem
 from pygromos.simulations.hpc_queuing.submission_systems.local import LOCAL
@@ -17,20 +19,65 @@ from pygromos.utils import bash
 
 def TI_sampling(in_gromos_system: Gromos_System, project_dir: str, step_name="lambda_sampling",
                 lambda_values: List[float] = np.arange(0, 1.1, 0.1), subSystem: _SubmissionSystem = LOCAL(),
-                n_simulation_repetitions: int = 3, n_equilibrations: int = 1):
+                n_productions: int = 3, n_equilibrations: int = 1, randomize: bool = False, dual_cnf: List[str] = None):
+    """
+        This function will automatically submit N independent (different lambda)
+        MD simulations with a lambda dependent potential energy.
+    
+        Parameters
+        ----------
+            in_gromos_system: Gromos_System
+                input gromos system
+            project_dir: str
+                directory in which simulation input files are found
+            step_name: str
+                subdirectory of project_dir, in which we will write the output
+                important: allows to run multiple random seeds with a different "step_name"
+            lambda_values: List [float]
+                List of lambda values for each independent simulation
+            subSystem: _SubmissionSystem
+                where will the calculation run
+            n_productions: int
+                number of chunks each independent simulation is broken down into
+            n_equilibrations: int
+                number of chunks of equilibration preceding the production for each independent simulation
+            randomize: bool
+                Choose a random number for the initial random seed (same for all lambda values)
+            dual_cnf: List [str], optional
+                If provided, should be the path to two conformations (matching end states A and B) which
+                can be used as initial conformations 
+                Simulations with a lambda value between 0 and 0.5 will use the first as starting conformation
+                
+        Returns
+        --------
+            lam_system: Gromos_System
+                Gromos system of the simulation submitted last
+    """
+
 
     work_dir = bash.make_folder(project_dir + "/" + step_name)
+    
+    # Select a random seed here so all lambda windows have the same
+    if randomize: in_gromos_system.imd.randomize_seed()
+    
     in_gromos_system.save(work_dir)
-    sys_path = in_gromos_system.save(work_dir+"/"+step_name+"_input.obj") #Ugly workaround for deepcopy
     general_system_name_prefix = in_gromos_system.name
 
     lam_systems = []
     for lam in lambda_values:
-        lam = np.round(lam, 2)
+        lam = np.round(lam, 4)
 
-        lam_system = Gromos_System.load(sys_path)
+        lam_system = deepcopy(in_gromos_system)
         lam_system.name = general_system_name_prefix+"_l_" + str(lam)
         lam_system.work_folder = work_dir
+        
+        # Choose different conformations depending on lambda point. 
+        # e.g. this allows to use RE-EDS SSM conformations.
+        # dual_cnf[i] contains the path of the cnf to use
+        if dual_cnf is not None and lam <= 0.5:
+            lam_system.cnf = Cnf(dual_cnf[0])
+        elif dual_cnf is not None:
+            lam_system.cnf = Cnf(dual_cnf[1])
 
         # IMD
         ## Pertubation
@@ -39,22 +86,23 @@ def TI_sampling(in_gromos_system: Gromos_System, project_dir: str, step_name="la
                                   ALPHC=0.5, ALPHLJ=0.5, NLAM=2, NSCALE=0)
         lam_system.imd.add_block(block=pert_block)
 
-        ###Calculate additional lambda points for end-states
+        ###Calculate additional lambda points
         if(not hasattr(lam_system, "PRECALCLAM")):
-            precalc_lam_block = PRECALCLAM(NRLAM=2, MINLAM=0, MAXLAM=1)
+            # Note: This assumes uniformely distributed lambda values
+            precalc_lam_block = PRECALCLAM(NRLAM=len(lambda_values), MINLAM=0, MAXLAM=1)
             lam_system.imd.add_block(block=precalc_lam_block)
 
         # Submit
         out_gromos_system = _TI_lam_step(in_gromos_system=lam_system, project_dir=work_dir,
                                                 step_name=lam_system.name, submission_system=subSystem,
                                                 in_imd_path=None,
-                                                simulation_runs=n_simulation_repetitions,
+                                                simulation_runs=n_productions,
                                                 equilibration_runs=n_equilibrations)
 
         out_gromos_system.save(out_gromos_system.work_folder + "/sd_out_system.obj")
         lam_systems.append(out_gromos_system)
 
-    return lam_system, out_gromos_system._last_jobID
+    return lam_system
 
 
 def _TI_lam_step(in_gromos_system: Gromos_System, project_dir: str, step_name: str = "lam", in_imd_path=None,

--- a/pygromos/tests/test_simulation_blocks/test_simulation_runner_blocks.py
+++ b/pygromos/tests/test_simulation_blocks/test_simulation_runner_blocks.py
@@ -53,4 +53,4 @@ class test_simulation_blocks(unittest.TestCase):
         self.gromSystem.imd = template_md
         pygromos.simulations.modules.ti_modules.TI_sampling(in_gromos_system=self.gromSystem, project_dir=self.tmp_test_dir,
                                                             lambda_values = np.arange(0, 1.1, 0.1), subSystem = self.submissionSystem,
-                                                            n_simulation_repetitions = 3, n_equilibrations = 1)
+                                                            n_productions = 3, n_equilibrations = 1)


### PR DESCRIPTION
## Description
This merge request addresses the following:

- Addition of documentation to the options in ti_modules.py
- Addition of two new options (randomize and dual_cnf) to select a random seed and provide specific conformations depending on the lambda value (which allows to use for example the RE-EDS SSM conformations as input)

- Very minor fixes (deepcopy instead of the old hack, more lenient rounding of values, ensuring the PRECALCLAM block calculates the potential energies at all lambda values so MBAR can be used)

## Status
- [ ] Ready to go