### PR TITLE
update_reinitialization for simulations

### DIFF
--- a/pygromos/simulations/hpc_queuing/job_scheduling/schedulers/scheduler_functions.py
+++ b/pygromos/simulations/hpc_queuing/job_scheduling/schedulers/scheduler_functions.py
@@ -68,7 +68,7 @@ def chain_submission(simSystem:Gromos_System,
                      run_analysis_script_every_x_runs: int = 0, in_analysis_script_path: str = "",
                      start_run_index: int = 1,
                      prefix_command: str = "", previous_job_ID: int = None, work_dir: str = None,
-                     initialize_first_run: bool = True, reinitialize: bool = False,
+                     initialize_first_run: bool = True, reinitialize_every_run: bool = False,
                      verbose: bool = False, verbose_lvl:int = 1):
     """
 
@@ -91,7 +91,7 @@ def chain_submission(simSystem:Gromos_System,
     previous_job_ID
     work_dir
     initialize_first_run
-    reinitialize
+    reinitialize_every_run
         initialize_first_run must be False
     verbose
 
@@ -157,6 +157,7 @@ def chain_submission(simSystem:Gromos_System,
             md_args += "-nmpi " + str(job_submission_system.nmpi) + "\n"
             md_args += "-nomp " + str(job_submission_system.nomp) + "\n"
             md_args += "-initialize_first_run "+str(initialize_first_run)+ "\n"
+            md_args += "-reinitialize_every_run "+str(reinitialize_every_run)+ "\n"
             md_args += "-gromosXX_bin_dir " + str(simSystem.gromosXX.bin) + "\n"        
     
             if(work_dir is not None):

--- a/pygromos/simulations/hpc_queuing/job_scheduling/schedulers/simulation_scheduler.py
+++ b/pygromos/simulations/hpc_queuing/job_scheduling/schedulers/simulation_scheduler.py
@@ -21,6 +21,7 @@ def do(in_simSystem: Gromos_System,
        simulation_run_num: int,
        equilibration_run_num: int = 0,
        work_dir: str = None,
+       initialize_first_run= False, reinitialize= False,
        analysis_script_path: str = None,
        submission_system:_SubmissionSystem = LSF(),
        previous_job_ID: int = None, no_double_submit:bool=False,
@@ -131,7 +132,7 @@ def do(in_simSystem: Gromos_System,
                              chain_job_repetitions=equilibration_run_num, worker_script=workerScript.__file__,
                              job_submission_system=submission_system, start_run_index = 1,
                              prefix_command =  "", previous_job_ID = previous_job_ID, work_dir = work_dir,
-                             initialize_first_run = True, reinitialize = False,
+                             initialize_first_run = initialize_first_run, reinitialize = reinitialize,
                              verbose = job_verb)
 
         ## MD
@@ -145,7 +146,7 @@ def do(in_simSystem: Gromos_System,
                          worker_script=workerScript.__file__,
                          job_submission_system=submission_system,
                          prefix_command =  "", previous_job_ID = previous_job_ID, work_dir = None,
-                         initialize_first_run= False, reinitialize= False,
+                         initialize_first_run= initialize_first_run, reinitialize= reinitialize,
                          verbose = job_verb)
 
         ana_previous_job_ID = previous_job_ID

--- a/pygromos/simulations/hpc_queuing/job_scheduling/schedulers/simulation_scheduler.py
+++ b/pygromos/simulations/hpc_queuing/job_scheduling/schedulers/simulation_scheduler.py
@@ -21,7 +21,7 @@ def do(in_simSystem: Gromos_System,
        simulation_run_num: int,
        equilibration_run_num: int = 0,
        work_dir: str = None,
-       initialize_first_run= False, reinitialize= False,
+       initialize_first_run= False, reinitialize_every_run= False,
        analysis_script_path: str = None,
        submission_system:_SubmissionSystem = LSF(),
        previous_job_ID: int = None, no_double_submit:bool=False,
@@ -132,7 +132,7 @@ def do(in_simSystem: Gromos_System,
                              chain_job_repetitions=equilibration_run_num, worker_script=workerScript.__file__,
                              job_submission_system=submission_system, start_run_index = 1,
                              prefix_command =  "", previous_job_ID = previous_job_ID, work_dir = work_dir,
-                             initialize_first_run = initialize_first_run, reinitialize = reinitialize,
+                             initialize_first_run = initialize_first_run, reinitialize_every_run = reinitialize_every_run,
                              verbose = job_verb)
 
         ## MD
@@ -146,7 +146,7 @@ def do(in_simSystem: Gromos_System,
                          worker_script=workerScript.__file__,
                          job_submission_system=submission_system,
                          prefix_command =  "", previous_job_ID = previous_job_ID, work_dir = None,
-                         initialize_first_run= initialize_first_run, reinitialize= reinitialize,
+                         initialize_first_run= initialize_first_run, reinitialize_every_run= reinitialize_every_run,
                          verbose = job_verb)
 
         ana_previous_job_ID = previous_job_ID

--- a/pygromos/simulations/hpc_queuing/job_scheduling/workers/simulation_workers/simulation_run_worker.py
+++ b/pygromos/simulations/hpc_queuing/job_scheduling/workers/simulation_workers/simulation_run_worker.py
@@ -21,7 +21,7 @@ def work(out_dir : str, in_cnf_path : str, in_imd_path : str, in_top_path : str,
          in_qmmm_path:str=None, out_trc:bool=False, out_tre: bool=False,
          out_trg: bool = False, out_trv: bool = False, out_trf: bool = False, out_trs: bool = False,
          nmpi: int = 1, nomp: int = 1,
-         reinitialize: bool = False, initialize_first_run:bool = True,
+         reinitialize_every_run: bool = False, initialize_first_run:bool = True,
          gromosXX_bin_dir: str = None, work_dir: str = None, zip_trajectories: bool = True, **kwargs):
     """
     Executed by repex_EDS_long_production_run as workers
@@ -114,7 +114,7 @@ def work(out_dir : str, in_cnf_path : str, in_imd_path : str, in_top_path : str,
             is_energymin_sim = True
             
     #Adapt Initializations:
-    if (reinitialize or (initialize_first_run and runID == 1)):
+    if (reinitialize_every_run or (initialize_first_run and runID == 1)):
         imd_file.INITIALISE.NTIVEL = 1
 
         if(hasattr(imd_file, "CONSTRAINT")):

--- a/pygromos/simulations/hpc_queuing/job_scheduling/workers/simulation_workers/simulation_run_worker.py
+++ b/pygromos/simulations/hpc_queuing/job_scheduling/workers/simulation_workers/simulation_run_worker.py
@@ -121,10 +121,8 @@ def work(out_dir : str, in_cnf_path : str, in_imd_path : str, in_top_path : str,
                  imd_file.INITIALISE.NTISHK = 0 if(imd_file.CONSTRAINT.NTC > 0) else 1
          
         if(hasattr(imd_file, "MULTIBATH")):
-                 imd_file.INITIALISE.NTINHT = 0 if(imd_file.MULTIBATH.ALGORITHM < 1) else 1
+                 imd_file.INITIALISE.NTINHT = 0 if(imd_file.MULTIBATH.ALGORITHM <= 1) else 1
                   
-        if(hasattr(imd_file, "PRESSURESCALE")):
-                 imd_file.INITIALISE.NTINHB = 0  if(imd_file.PRESSURESCALE < 1) else 1
                   
         imd_file.INITIALISE.NTISHI = 0 if(hasattr(cnf_file, "LATTICESHIFT")) else 1
 
@@ -134,10 +132,6 @@ def work(out_dir : str, in_cnf_path : str, in_imd_path : str, in_top_path : str,
 
         if (is_stochastic_dynamics_sim):
             imd_file.INITIALISE.NTISTI = 1
-        elif(is_energymin_sim):
-            pass
-        else:
-            imd_file.INITIALISE.NTISHK = 3
 
     elif(initialize_first_run and runID > 1):
         imd_file.INITIALISE.NTIVEL = 0

--- a/pygromos/simulations/modules/general_simulation_modules.py
+++ b/pygromos/simulations/modules/general_simulation_modules.py
@@ -23,7 +23,7 @@ from pygromos.utils.utils import spacer as spacer, time_wait_s_for_filesystem
 def simulation(in_gromos_simulation_system:Gromos_System, override_project_dir:str=None,
                step_name:str="sim", in_imd_path:str = None,
                submission_system:_SubmissionSystem=LOCAL(), simulation_runs:int=1, equilibration_runs:int = 0,
-               previous_simulation_run:int=None, force_simulation:bool=False,
+               previous_simulation_run:int=None, force_simulation:bool=False, initialize_first_run= False, reinitialize_every_run= False,
                analysis_script:callable = simulation_analysis.do, analysis_control_dict:dict = None,
                verbose:bool = True, verbose_lvl:int=1, _template_imd_path:str=None) -> Gromos_System:
     """
@@ -146,6 +146,8 @@ def simulation(in_gromos_simulation_system:Gromos_System, override_project_dir:s
             "equilibration_run_num": equilibration_runs,
             "submission_system": submission_system,
             "analysis_script_path": in_analysis_script_path,
+            "initialize_first_run": initialize_first_run,
+            "reinitialize": reinitialize_every_run,
             "verbose": verbose,
             "verbose_lvl": verbose_lvl
         })
@@ -170,6 +172,7 @@ def simulation(in_gromos_simulation_system:Gromos_System, override_project_dir:s
             last_jobID = simulation_scheduler.do(in_simSystem=gromos_system, out_dir_path=out_simulation_dir,
                                                  simulation_run_num=simulation_runs, equilibration_run_num=equilibration_runs,
                                                  submission_system=submission_system, previous_job_ID=previous_simulation_run,
+                                                 initialize_first_run= initialize_first_run, reinitialize= reinitialize_every_run,
                                                  analysis_script_path=in_analysis_script_path, verbose=verbose, verbose_lvl=verbose_lvl)
     except Exception as err:
         traceback.print_exception(*sys.exc_info())

--- a/pygromos/simulations/modules/general_simulation_modules.py
+++ b/pygromos/simulations/modules/general_simulation_modules.py
@@ -147,7 +147,7 @@ def simulation(in_gromos_simulation_system:Gromos_System, override_project_dir:s
             "submission_system": submission_system,
             "analysis_script_path": in_analysis_script_path,
             "initialize_first_run": initialize_first_run,
-            "reinitialize": reinitialize_every_run,
+            "reinitialize_every_run": reinitialize_every_run,
             "verbose": verbose,
             "verbose_lvl": verbose_lvl
         })
@@ -172,7 +172,7 @@ def simulation(in_gromos_simulation_system:Gromos_System, override_project_dir:s
             last_jobID = simulation_scheduler.do(in_simSystem=gromos_system, out_dir_path=out_simulation_dir,
                                                  simulation_run_num=simulation_runs, equilibration_run_num=equilibration_runs,
                                                  submission_system=submission_system, previous_job_ID=previous_simulation_run,
-                                                 initialize_first_run= initialize_first_run, reinitialize= reinitialize_every_run,
+                                                 initialize_first_run= initialize_first_run, reinitialize_every_run= reinitialize_every_run,
                                                  analysis_script_path=in_analysis_script_path, verbose=verbose, verbose_lvl=verbose_lvl)
     except Exception as err:
         traceback.print_exception(*sys.exc_info())

--- a/pygromos/simulations/modules/preset_simulation_modules.py
+++ b/pygromos/simulations/modules/preset_simulation_modules.py
@@ -14,7 +14,7 @@ from pygromos.simulations.hpc_queuing.submission_systems.local import LOCAL
 """
 def emin(in_gromos_system: Gromos_System, step_name: str = "emin", override_project_dir: str=None, in_imd_path=None,
          submission_system: _SubmissionSystem = LOCAL(), simulation_runs: int = 1, equilibration_runs: int = 0,
-         previous_simulation_run: int = None, _template_imd_path:str=template_emin,
+         previous_simulation_run: int = None, _template_imd_path:str=template_emin,  initialize_first_run= False,
          analysis_script: callable = simulation_analysis.do) -> Tuple[Gromos_System, int]:
     template_emin_control_dict = simulation_analysis.template_control_dict
     template_emin_control_dict['concat']['cat_trc'] = False
@@ -30,25 +30,25 @@ def emin(in_gromos_system: Gromos_System, step_name: str = "emin", override_proj
             template_emin_control_dict['concat']['cat_trg'] = False
 
     return simulation(in_gromos_simulation_system=in_gromos_system, override_project_dir=override_project_dir, previous_simulation_run=previous_simulation_run,
-                      step_name=step_name, in_imd_path=in_imd_path, submission_system=submission_system,
+                      step_name=step_name, in_imd_path=in_imd_path, submission_system=submission_system, initialize_first_run=initialize_first_run,
                       simulation_runs=simulation_runs, equilibration_runs=equilibration_runs, analysis_control_dict = template_emin_control_dict,
                       analysis_script=analysis_script, _template_imd_path=_template_imd_path)
 
 
 def md(in_gromos_system: Gromos_System, step_name: str = "md",  override_project_dir: str=None, in_imd_path=None,
-       submission_system: _SubmissionSystem = LOCAL(), simulation_runs: int = 1, equilibration_runs: int = 0,
+       submission_system: _SubmissionSystem = LOCAL(), simulation_runs: int = 1, equilibration_runs: int = 0,  initialize_first_run= False, reinitialize_every_run= False,
        previous_simulation_run: int = None, _template_imd_path:str=template_md, analysis_script: callable = simulation_analysis.do) -> Tuple[Gromos_System, int]:
     return simulation(in_gromos_simulation_system=in_gromos_system, override_project_dir=override_project_dir, previous_simulation_run=previous_simulation_run,
-                      step_name=step_name, in_imd_path=in_imd_path, submission_system=submission_system,
+                      step_name=step_name, in_imd_path=in_imd_path, submission_system=submission_system, initialize_first_run=initialize_first_run,
                       simulation_runs=simulation_runs, equilibration_runs=equilibration_runs,
                       analysis_script=analysis_script, _template_imd_path=_template_imd_path)
 
 
 def sd(in_gromos_system: Gromos_System, step_name: str = "sd",  override_project_dir: str=None, in_imd_path=None,
-       submission_system: _SubmissionSystem = LOCAL(), simulation_runs: int = 1, equilibration_runs: int = 0,
+       submission_system: _SubmissionSystem = LOCAL(), simulation_runs: int = 1, equilibration_runs: int = 0,  initialize_first_run= False, reinitialize_every_run= False,
        previous_simulation_run: int = None, _template_imd_path:str=template_sd, analysis_script: callable = simulation_analysis.do) -> Tuple[Gromos_System, int]:
     return simulation(in_gromos_simulation_system=in_gromos_system, override_project_dir=override_project_dir, previous_simulation_run=previous_simulation_run,
-                      step_name=step_name, in_imd_path=in_imd_path, submission_system=submission_system,
+                      step_name=step_name, in_imd_path=in_imd_path, submission_system=submission_system, initialize_first_run=initialize_first_run,
                       simulation_runs=simulation_runs, equilibration_runs=equilibration_runs,
                       analysis_script=analysis_script, _template_imd_path=_template_imd_path)
 
@@ -71,7 +71,7 @@ def thermalisation(in_gromos_system: Gromos_System, temperatures = np.linspace(6
 
             # Last run
             return simulation(in_gromos_simulation_system=in_gromos_system, override_project_dir=override_project_dir, previous_simulation_run=previous_simulation_run,
-                              step_name=step_name, in_imd_path=in_imd_path, submission_system=submission_system,
+                              step_name=step_name, in_imd_path=in_imd_path, submission_system=submission_system, 
                               simulation_runs=simulation_runs, equilibration_runs=equilibration_runs,
                               analysis_script=analysis_script, _template_imd_path=_template_imd_path)
 


### PR DESCRIPTION
This PR enables the passing of reinitialization flags from the simulation layer to the worker.

Todos:
- [x] Documentation
- [x] Simulation passes now reinitialize -> worker
- [x] bring initialize_first_run to MD, EQ, SD, EMIN?
- [x] refactor - name of reinitialize
- [x] check if initiliazer options are correct (especially Barostat)

