### PR TITLE
Update build_docs.sh

### DIFF
--- a/docs/sphinx_project/build_docs.sh
+++ b/docs/sphinx_project/build_docs.sh
@@ -14,4 +14,4 @@ python conf.py;
 ##execute making docu
 make html;
 
-cp -r _build/html/* ../
+cp -rf _build/html/* ../


### PR DESCRIPTION
less complaining by CI
 
This simply adds the force flag for the final cp, in order to remove the crash reason for the CI.